### PR TITLE
add a note to warnings on emission detailling the original call site

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ impl<T> DiagnosticResult<T> {
     ///
     /// The message can be anything that implements `ToString` (incl. everything `Display`),
     /// this means you can use format_args!() to avoid intermediate allocations
+    ///
+    /// A note will be added to the warning when emitted, which highlights the original call site.
     pub fn warn_spanned<MSG: ToString, SPN: MultiSpan>(value: T, span: SPN, message: MSG) -> Self {
         Self::Warning(
             value,
@@ -154,7 +156,6 @@ pub struct Diagnostic {
 enum Level {
     Error,
     Warning,
-    #[expect(unused)]
     Note,
     Help,
 }
@@ -267,7 +268,16 @@ impl From<DiagnosticStream> for TokenStream1 {
 
 impl Diagnostic {
     /// Convert to a [proc_macro::Diagnostic] and then emit
-    fn emit(self) {
+    fn emit(mut self) {
+        if matches!(self.level, Level::Warning) {
+            let source_note = Diagnostic {
+                level: Level::Note,
+                message: "this warning originates from the macro invocation here".to_string(),
+                spans: vec![Span::call_site()],
+                children: vec![],
+            };
+            self.children.push(source_note);
+        }
         let spans = self.as_spans();
         let mut pm_diagnostic =
             proc_macro::Diagnostic::spanned(spans, self.level.into(), self.message);

--- a/tests/compilation/examples/fail_helpful_warning.stderr
+++ b/tests/compilation/examples/fail_helpful_warning.stderr
@@ -17,4 +17,9 @@ help: this might help you understand
    |
 10 | helpful_warning!();
    | ^^^^^^^^^^^^^^^^^^
+note: this warning originates from the macro invocation here
+  --> tests/compilation/examples/fail_helpful_warning.rs:10:1
+   |
+10 | helpful_warning!();
+   | ^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `helpful_warning` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compilation/examples/fail_span_slice_help.stderr
+++ b/tests/compilation/examples/fail_span_slice_help.stderr
@@ -17,4 +17,9 @@ help: help with multiple spans
    |
 10 | span_slice_help!(help1 help2);
    |                  ^^^^^ ^^^^^
+note: this warning originates from the macro invocation here
+  --> tests/compilation/examples/fail_span_slice_help.rs:10:1
+   |
+10 | span_slice_help!(help1 help2);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in the macro `span_slice_help` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compilation/examples/fail_vec_span_warn.stderr
+++ b/tests/compilation/examples/fail_vec_span_warn.stderr
@@ -11,3 +11,10 @@ warning: warning with multiple spans
    |
 10 | vec_span_warn!(foo bar baz);
    |                ^^^ ^^^ ^^^
+   |
+note: this warning originates from the macro invocation here
+  --> tests/compilation/examples/fail_vec_span_warn.rs:10:1
+   |
+10 | vec_span_warn!(foo bar baz);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this warning originates in the macro `vec_span_warn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compilation/examples/fail_warn.stderr
+++ b/tests/compilation/examples/fail_warn.stderr
@@ -12,4 +12,9 @@ warning: be careful
 10 | warn!();
    | ^^^^^^^
    |
+note: this warning originates from the macro invocation here
+  --> tests/compilation/examples/fail_warn.rs:10:1
+   |
+10 | warn!();
+   | ^^^^^^^
    = note: this warning originates in the macro `warn` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary by Sourcery

Add a diagnostic note to warnings indicating the original macro invocation call site on emission.

Enhancements:
- Attach a note diagnostic to emitted warnings pointing to the macro invocation call site for clearer origin tracking.

Tests:
- Update compilation stderr expectation files to account for the new warning note output.