### PR TITLE
Option::or_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # proc_macro2_diagnostic changelog
 
+## [v0.5.0](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.5.0)
+
+### Breaking changes
+
+- Removed `FromResidual<Result<!,DiagnosticResult<!>>` - this breaks invocations of `Option::ok_or(error())?;`, which was nightly-only: see below for improved syntax on both stable & nightly.
+
+### New features
+
+- Added `trait ToDiagnostic` and `impl ToDiagnostic for Option` allowing `Option::or_error()`, `Option::or_error_spanned()` & `Option::or_warn_spanned_with_default()` on both stable & nightly.
+
 ## [v0.4.0](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.4.0)
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macro2_diagnostic"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 readme = "README.md"
 description = "Use `Diagnostic` compiler messages from proc_macro2 code with Result-like syntax."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,37 +305,6 @@ pub trait AsDiagnostic<T> {
 }
 
 /// Converts `Err` to `Error`.
-#[cfg(has_try_trait_v2)]
-impl<T, E> AsDiagnostic<T> for Result<T, E>
-where
-    // TODO: Validate blanket impl availble where Diagnostic: From<E>
-    E: Into<DiagnosticResult<T>>,
-{
-    fn add_help<MSG: ToString, SPN: MultiSpan>(
-        self,
-        span: SPN,
-        message: MSG,
-    ) -> DiagnosticResult<T> {
-        match self {
-            Result::Ok(val) => Ok(val),
-            Result::Err(e) => e.into().add_help(span, message),
-        }
-    }
-
-    fn add_note<MSG: ToString, SPN: MultiSpan>(
-        self,
-        span: SPN,
-        message: MSG,
-    ) -> DiagnosticResult<T> {
-        match self {
-            Result::Ok(val) => Ok(val),
-            Result::Err(e) => e.into().add_note(span, message),
-        }
-    }
-}
-
-/// Converts `Err` to `Error`.
-#[cfg(not(has_try_trait_v2))]
 impl<T, E> AsDiagnostic<T> for Result<T, E>
 where
     Diagnostic: From<E>,
@@ -348,10 +317,18 @@ where
         match self {
             Result::Ok(val) => Ok(val),
             Result::Err(e) => {
-                let mut diag = Diagnostic::from(e);
-                diag.add_help(span, message);
-                // TODO: has_diagnostic
-                Err(diag)
+                let mut diagnostic = Diagnostic::from(e);
+                diagnostic.add_help(span, message);
+                #[cfg(not(has_try_trait_v2))]
+                {
+                    Err(diagnostic)
+                }
+                #[cfg(has_try_trait_v2)]
+                {
+                    DiagnosticResult {
+                        inner: Error(diagnostic),
+                    }
+                }
             }
         }
     }
@@ -364,10 +341,18 @@ where
         match self {
             Result::Ok(val) => Ok(val),
             Result::Err(e) => {
-                let mut diag = Diagnostic::from(e);
-                diag.add_note(span, message);
-                // TODO: has_diagnostic
-                Err(diag)
+                let mut diagnostic = Diagnostic::from(e);
+                diagnostic.add_note(span, message);
+                #[cfg(not(has_try_trait_v2))]
+                {
+                    Err(diagnostic)
+                }
+                #[cfg(has_try_trait_v2)]
+                {
+                    DiagnosticResult {
+                        inner: Error(diagnostic),
+                    }
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,23 +596,6 @@ impl<T> std::ops::Residual<T> for DiagnosticResult<!> {
     type TryType = DiagnosticResult<T>;
 }
 
-/// If you inadvertently (or for "reasons") create a `Result<_, DiagnosticResult<!>>` then `?` will
-/// convert an `Err` to a simple `DiagnosticResult<_>::Error`.
-#[cfg(all(has_never_type, has_try_trait_v2_residual))]
-impl<T> std::ops::FromResidual<Result<std::convert::Infallible, DiagnosticResult<!>>>
-    for DiagnosticResult<T>
-{
-    fn from_residual(result: Result<std::convert::Infallible, DiagnosticResult<!>>) -> Self {
-        match result {
-            Result::Err(e) => match e.inner {
-                Error(diagnostic) => Self {
-                    inner: DiagnosticResult_::Error(diagnostic),
-                },
-            },
-        }
-    }
-}
-
 #[cfg(has_try_trait_v2)]
 impl<T, E> std::ops::FromResidual<Result<std::convert::Infallible, E>> for DiagnosticResult<T>
 where
@@ -709,12 +692,12 @@ mod tests {
         )
     }
 
-    #[test]
-    fn ok_or() {
-        fn five() -> DiagnosticResult<i32> {
-            let five = Some(5).ok_or(error("oops!"))?;
-            Ok(five)
-        }
-        assert_eq!(five().unwrap(), 5)
-    }
+    // #[test]
+    // fn ok_or() {
+    //     fn five() -> DiagnosticResult<i32> {
+    //         let five = Some(5).ok_or(error("oops!"))?;
+    //         Ok(five)
+    //     }
+    //     assert_eq!(five().unwrap(), 5)
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,4 +708,13 @@ mod tests {
             DiagnosticResultKind::Ok
         )
     }
+
+    #[test]
+    fn ok_or() {
+        fn five() -> DiagnosticResult<i32> {
+            let five = Some(5).ok_or(error("oops!"))?;
+            Ok(five)
+        }
+        assert_eq!(five().unwrap(), 5)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,15 +214,70 @@ pub fn warn_spanned<T, MSG: ToString, SPN: MultiSpan>(
     }
 }
 
+/// Provides methods to generate a diagnostic in "failure" case. This is a bit like
+/// `Option::ok_or()` but returns a `DiagnosticResult` and can be implemented on
+/// additional types.
 pub trait ToDiagnostic<T> {
+    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create an error, spanning
+    /// the call site with the given `message`
     fn or_error<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>;
+    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create an errorat the
+    /// given `span` with the given `message`
+    fn or_error_spanned<MSG: ToString, SPN: MultiSpan>(
+        self,
+        span: SPN,
+        message: MSG,
+    ) -> DiagnosticResult<T>;
+    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create a warning, at the
+    /// given `the call site` with the given `message` and containing the default value for `T`
+    fn or_warn_with_default<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>
+    where
+        T: Default;
+    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create a warning, at the
+    /// given `span` with the given `message` and containing the default value for `T`
+    fn or_warn_spanned_with_default<MSG: ToString, SPN: MultiSpan>(
+        self,
+        span: SPN,
+        message: MSG,
+    ) -> DiagnosticResult<T>
+    where
+        T: Default;
 }
 
 impl<T> ToDiagnostic<T> for Option<T> {
     fn or_error<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T> {
+        self.or_error_spanned(Span::call_site(), message)
+    }
+
+    fn or_error_spanned<MSG: ToString, SPN: MultiSpan>(
+        self,
+        span: SPN,
+        message: MSG,
+    ) -> DiagnosticResult<T> {
         match self {
             Some(val) => Ok(val),
-            None => error(message),
+            None => error_spanned(span, message),
+        }
+    }
+
+    fn or_warn_with_default<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>
+    where
+        T: Default,
+    {
+        self.or_warn_spanned_with_default(Span::call_site(), message)
+    }
+
+    fn or_warn_spanned_with_default<MSG: ToString, SPN: MultiSpan>(
+        self,
+        span: SPN,
+        message: MSG,
+    ) -> DiagnosticResult<T>
+    where
+        T: Default,
+    {
+        match self {
+            Some(val) => Ok(val),
+            None => warn_spanned(Default::default(), span, message),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,19 @@ pub fn warn_spanned<T, MSG: ToString, SPN: MultiSpan>(
     }
 }
 
+pub trait ToDiagnostic<T> {
+    fn or_error<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>;
+}
+
+impl<T> ToDiagnostic<T> for Option<T> {
+    fn or_error<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T> {
+        match self {
+            Some(val) => Ok(val),
+            None => error(message),
+        }
+    }
+}
+
 pub trait AsDiagnostic<T> {
     /// Add a `Help` message to an existing _error_ or _warning_ at one or more `Span`s.
     ///
@@ -692,12 +705,12 @@ mod tests {
         )
     }
 
-    // #[test]
-    // fn ok_or() {
-    //     fn five() -> DiagnosticResult<i32> {
-    //         let five = Some(5).ok_or(error("oops!"))?;
-    //         Ok(five)
-    //     }
-    //     assert_eq!(five().unwrap(), 5)
-    // }
+    #[test]
+    fn ok_or() {
+        fn five() -> DiagnosticResult<i32> {
+            let five = Some(5).or_error("oops!")?;
+            Ok(five)
+        }
+        assert_eq!(five().unwrap(), 5)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ pub fn error_spanned<T, MSG: ToString, SPN: MultiSpan>(
 ///
 /// # Considerations for testing, etc.
 /// - If code used outside a proc_macro context attempts to emit a Warning this will cause a
-///   runtime failure. Be careful when contructing Warnings in code which will be subject to
+///   runtime failure. Be careful when constructing Warnings in code which will be subject to
 ///   unit tests or used in other contexts, e.g. in a build script.
 pub fn warn_spanned<T, MSG: ToString, SPN: MultiSpan>(
     value: T,
@@ -226,7 +226,7 @@ pub trait ToDiagnostic<T> {
     /// Wrap the contained `T` in a `DiagnosticResult<T>` or create an error, spanning
     /// the call site with the given `message`
     fn or_error<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>;
-    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create an errorat the
+    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create an error at the
     /// given `span` with the given `message`
     fn or_error_spanned<MSG: ToString, SPN: MultiSpan>(
         self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,11 @@ pub fn error_spanned<T, MSG: ToString, SPN: MultiSpan>(
 /// # Stable / Nightly
 /// - Where try_trait_v2 is not available `Warnings` will be emitted immediately. See the readme
 ///   for more information
+///
+/// # Considerations for testing, etc.
+/// - If code used outside a proc_macro context attempts to emit a Warning this will cause a
+///   runtime failure. Be careful when contructing Warnings in code which will be subject to
+///   unit tests or used in other contexts, e.g. in a build script.
 pub fn warn_spanned<T, MSG: ToString, SPN: MultiSpan>(
     value: T,
     #[allow(
@@ -229,12 +234,20 @@ pub trait ToDiagnostic<T> {
         message: MSG,
     ) -> DiagnosticResult<T>;
     /// Wrap the contained `T` in a `DiagnosticResult<T>` or create a warning, at the
-    /// given `the call site` with the given `message` and containing the default value for `T`
-    fn or_warn_with_default<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>
-    where
-        T: Default;
-    /// Wrap the contained `T` in a `DiagnosticResult<T>` or create a warning, at the
     /// given `span` with the given `message` and containing the default value for `T`
+    ///     
+    ///
+    /// A note will be added to the warning when emitted, which highlights the original call site,
+    /// unless you add one manually.
+    ///
+    /// # Stable / Nightly
+    /// - Where try_trait_v2 is not available `Warnings` will be emitted immediately. See the readme
+    ///   for more information
+    ///
+    /// # Considerations for testing, etc.
+    /// - If code used outside a proc_macro context attempts to emit a Warning this will cause a
+    ///   runtime failure. Be careful when contructing Warnings in code which will be subject to
+    ///   unit tests or used in other contexts, e.g. in a build script.
     fn or_warn_spanned_with_default<MSG: ToString, SPN: MultiSpan>(
         self,
         span: SPN,
@@ -258,13 +271,6 @@ impl<T> ToDiagnostic<T> for Option<T> {
             Some(val) => Ok(val),
             None => error_spanned(span, message),
         }
-    }
-
-    fn or_warn_with_default<MSG: ToString>(self, message: MSG) -> DiagnosticResult<T>
-    where
-        T: Default,
-    {
-        self.or_warn_spanned_with_default(Span::call_site(), message)
     }
 
     fn or_warn_spanned_with_default<MSG: ToString, SPN: MultiSpan>(


### PR DESCRIPTION
### Breaking changes

- Removed `FromResidual<Result<!,DiagnosticResult<!>>` - this breaks invocations of `Option::ok_or(error())?;`, which was nightly-only: see below for improved syntax on both stable & nightly.

### New features

- Added `trait ToDiagnostic` and `impl ToDiagnostic for Option` allowing `Option::or_error()`, `Option::or_error_spanned()` & `Option::or_warn_spanned_with_default()` on both stable & nightly.