### PR TITLE
try_v2 no derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # proc_macro2_diagnostic changelog
 
+## [v0.6.2](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.6.2)
+
+### Bug fixes
+
+- Remove circular dependency risk via `try_v2_derive`
+
 ## [v0.6.1](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.6.1)
 
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macro2_diagnostic"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 readme = "README.md"
 description = "Use `Diagnostic` compiler messages from proc_macro2 code with Result-like syntax."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85.1"
 [dependencies]
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 syn = "2.0.117"
-try_v2 = "0.7.3"
+try_v2 = { version = "0.7.4", default-features = false }
 
 [dev-dependencies]
 proc_macro2_diagnostic_fixture = { workspace = true }


### PR DESCRIPTION
Remove circular dependency risk via `try_v2_derive`