### PR TITLE
directly use `try_v2_traits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # proc_macro2_diagnostic changelog
 
+## [v0.6.3](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.6.2)
+
+### Bug fixes
+
+- Fully remove circular dependency risk via `try_v2_derive` by directly using `try_v2_traits`
+
 ## [v0.6.2](https://github.com/MusicalNinjaDad/proc_macro2_diagnostic/tree/v0.6.2)
 
 ### Bug fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macro2_diagnostic"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 readme = "README.md"
 description = "Use `Diagnostic` compiler messages from proc_macro2 code with Result-like syntax."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85.1"
 [dependencies]
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 syn = "2.0.117"
-try_v2 = { version = "0.7.4", default-features = false }
+try_v2_traits = "0.8.0"
 
 [dev-dependencies]
 proc_macro2_diagnostic_fixture = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::Span;
 #[cfg(has_try_trait_v2)]
-use try_v2::{Extract, Transform};
+use try_v2_traits::{Extract, Transform};
 
 #[cfg(has_try_trait_v2)]
 use crate::DiagnosticResult_::{Error, Ok as Ok_, Warning};


### PR DESCRIPTION
- Fully remove circular dependency risk via `try_v2_derive` by directly using `try_v2_traits`